### PR TITLE
ENH: Allow MySQL driver options to be specified in database.ini

### DIFF
--- a/core/Bootstrap.php
+++ b/core/Bootstrap.php
@@ -84,7 +84,15 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
         throw new Zend_Exception('It appears PDO is not setup to support MySQL. '.
                                  'Please check your PDO configuration.');
         }
-      $pdoParams = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true);
+      if(isset($configDatabase->database->params->driver_options))
+        {
+        $pdoParams = $configDatabase->database->params->driver_options->toArray();
+        }
+      else
+        {
+        $pdoParams = array();
+        }
+      $pdoParams[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = true;
       $params = array(
         'host' => $configDatabase->database->params->host,
         'username' => $configDatabase->database->params->username,


### PR DESCRIPTION
For example to connect over SSL:

database.params.driver_options.1010 = "/path/to/client-key.pem"
database.params.driver_options.1011 = "/path/to/client-cert.pem"
database.params.driver_options.1012 = "/path/to/ca-cert.pem"
