### PR TITLE
Fixing scalar detail back-button bug.

### DIFF
--- a/modules/tracker/public/js/trend/trend.view.js
+++ b/modules/tracker/public/js/trend/trend.view.js
@@ -97,6 +97,7 @@ midas.tracker.bindPlotEvents = function () {
         } else {
             scalarId = json.tracker.rightScalars[dataPoint.pointIndex].scalar_id;
         }
+        $('.webroot').val(json.global.webroot);
         midas.loadDialog('scalarPoint'+scalarId, '/tracker/scalar/details?scalarId='+scalarId);
         midas.showDialog('Scalar details', false, {width: 500});
     });


### PR DESCRIPTION
We really should handle dialog state better and figure out why the '.webroot'
div value gets set to an odd value when navigating to the page via the back
button.
