### PR TITLE
Forward /api/rest to /api/json

### DIFF
--- a/modules/api/controllers/RestController.php
+++ b/modules/api/controllers/RestController.php
@@ -1,0 +1,34 @@
+<?php
+/*=========================================================================
+ MIDAS Server
+ Copyright (c) Kitware SAS. 26 rue Louis Guérin. 69100 Villeurbanne, FRANCE
+ All rights reserved.
+ More information http://www.kitware.com
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+/**
+ * Rest controller for the api module.
+ *
+ * @deprecated
+ */
+class Api_RestController extends Api_AppController
+{
+    /** Pre dispatch. */
+    public function preDispatch()
+    {
+        $this->forward('json', 'index', 'api', $this->getAllParams());
+        parent::preDispatch();
+    }
+}


### PR DESCRIPTION
Although, note that /api/json and /api/rest are both deprecated.
