### PR TITLE
Add comment sorting configuration

### DIFF
--- a/modules/comments/constant/module.php
+++ b/modules/comments/constant/module.php
@@ -1,0 +1,25 @@
+<?php
+/*=========================================================================
+ Midas Server
+ Copyright Kitware SAS, 26 rue Louis Guérin, 69100 Villeurbanne, France.
+ All rights reserved.
+ For more information visit http://www.kitware.com/.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+
+define("OLDEST_FIRST",0);
+define("NEWEST_FIRST",1);
+
+?>

--- a/modules/comments/controllers/ConfigController.php
+++ b/modules/comments/controllers/ConfigController.php
@@ -1,0 +1,41 @@
+<?php
+/*=========================================================================
+ Midas Server
+ Copyright Kitware SAS, 26 rue Louis Guérin, 69100 Villeurbanne, France.
+ All rights reserved.
+ For more information visit http://www.kitware.com/.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+/**
+ * Config controller for the comments module.
+ */
+class Comments_ConfigController extends Comments_AppController
+{
+
+    public $_models = array('Setting','User');
+
+    public function indexAction()
+    {
+        $this->requireAdminPrivileges();
+        if($this->_request->isPost())
+          {
+          $this->view->commentOrder = $_POST['commentOrder'];
+          MidasLoader::loadModel("Setting")->setConfig('commentOrder',$this->view->commentOrder,"comments");
+          };
+
+
+        session_start();
+    }
+}

--- a/modules/comments/models/pdo/ItemcommentModel.php
+++ b/modules/comments/models/pdo/ItemcommentModel.php
@@ -28,8 +28,20 @@ class Comments_ItemcommentModel extends Comments_ItemcommentModelBase
      */
     public function getComments($item, $limit = 10, $offset = 0)
     {
+        /*
+         * Change the order of the retrieval based upon the user setting.  This changes the display
+         * order of the comments
+         *
+         * 'ASC' shows the oldest comment first, 'DESC' shows the newest first
+         */
+        if( MidasLoader::loadModel("Setting")->getValueByName("commentOrder","comments") == OLDEST_FIRST) {
+          $commentSort = "ASC";
+        }
+        else {
+          $commentSort = "DESC";
+        }
         $sql = $this->database->select()->where('item_id = ?', $item->getKey())->limit($limit, $offset)->order(
-            'date ASC'
+            'date ' . $commentSort
         );
 
         $rowset = $this->database->fetchAll($sql);

--- a/modules/comments/views/config/index.phtml
+++ b/modules/comments/views/config/index.phtml
@@ -1,0 +1,40 @@
+<?php
+/*=========================================================================
+ Midas Server
+ Copyright Kitware SAS, 26 rue Louis Guérin, 69100 Villeurbanne, France.
+ All rights reserved.
+ For more information visit http://www.kitware.com/.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+$this->declareVars('form', 'pageTitle');
+$this->headTitle($this->escape($this->pageTitle));
+?>
+
+<div class="viewMain">
+    <h1><?php  ?></h1>
+    <div>
+      <form  class='genericform' id='configForm' method='POST' action=''>
+      <h3> Comment Module Configuration </h3>
+      <p>Currently sorting comments by <b><?php if( MidasLoader::loadModel("Setting")->getValueByName("commentOrder","comments") ==0) { echo "OLDEST";} else { echo "NEWEST";};?></b> first.</p>
+      <label for"'commentOrder'>Order comments by</label>
+      <select name='commentOrder'>
+        <option value="<?php echo OLDEST_FIRST ?>">Oldest First</option>
+        <option value="<?php echo NEWEST_FIRST ?>">Newest First</option>
+      </form>
+    </div>
+    <div>
+      <input type='submit' value='Save Configuration'/>
+    </div>
+</div>


### PR DESCRIPTION
Add the capability to sort the Midas comments to show most recent first
or oldest first.  A simple select will determine the sorting order of the
comments as they are retrieved from the database (ASC vs DESC).

