### PR TITLE
Filter tracker trend data when Y axis limits change

### DIFF
--- a/modules/tracker/public/js/trend/trend.view.js
+++ b/modules/tracker/public/js/trend/trend.view.js
@@ -364,6 +364,7 @@ $(window).load(function () {
                 json.tracker.y2Min = container.find('input.y2Min').val();
                 json.tracker.y2Max = container.find('input.y2Max').val();
             }
+            var curveData = midas.tracker.extractCurveData(inputCurves);
             midas.tracker.renderChartArea(curveData, false);
             midas.tracker.updateUrlBar();
             container.dialog('close');


### PR DESCRIPTION
This issue shows up as points not being clickable.

I'll step through a bug reproduction scenario.

Here we have a trend with two submissions, one for branch `master` and one for branch `other`.  At first we see both points because all branches are shown.

![screen shot 2015-10-13 at 5 18 03 pm](https://cloud.githubusercontent.com/assets/595023/10468721/9fdecd5a-71ce-11e5-9b3c-ab8eae21006e.png)

Now we filter to the `other` branch, only one point is shown.

![screen shot 2015-10-13 at 5 18 29 pm](https://cloud.githubusercontent.com/assets/595023/10468727/ae600e5c-71ce-11e5-87fe-3a70cc0294f2.png)

We then change the Y axis limits to [0, 20].  Because we weren't filtering the `curveData` from the current set of filters (`curveData` was held in the closure for the Y axis change event handler), we get all the branches again, at least as far as the point data for plotting the curves.  So we see both points, even though the `other` branch filter is actually in place.

![screen shot 2015-10-13 at 5 18 50 pm](https://cloud.githubusercontent.com/assets/595023/10468772/f131ffb0-71ce-11e5-82de-38ea18fca758.png)

When we try to click on the point from the `other` branch, the backing data is there, and the point is clickable as normal.  When we click on the point from the `master` branch, that point doesn't exist in the curveData known to the click handler, so we have an undefined scalarId and hence a 403.

![screen shot 2015-10-13 at 5 19 07 pm](https://cloud.githubusercontent.com/assets/595023/10468786/1e721bfe-71cf-11e5-931f-6095947b89b8.png)

With this fix, after we change the Y axes to [0, 30], the branch filter remains in place, only the data from that filter is shown, and all of our points are clickable.

![screen shot 2015-10-13 at 5 25 57 pm](https://cloud.githubusercontent.com/assets/595023/10468884/9a4efd32-71cf-11e5-8c18-96747170cb12.png)



@jamiesnape @cpatrick 

