### PR TITLE
Update "uploadPerform" to set "Initial revision" if it applies

### DIFF
--- a/core/controllers/components/ApisystemComponent.php
+++ b/core/controllers/components/ApisystemComponent.php
@@ -581,7 +581,7 @@ class ApisystemComponent extends AppComponent
         }
 
         $license = array_key_exists('license', $args) ?  $args['license'] : null;
-        $changes = array_key_exists('changes', $args) ? $args['changes'] : '';
+        $changes = array_key_exists('changes', $args) ? $args['changes'] : 'Initial revision';
         $revisionNumber = null;
         if (isset($revision) && $revision !== false) {
             $revisionNumber = $revision->getRevision();


### PR DESCRIPTION
This commit ensures that the first revision of new item will always be
associated with the comment "Initial revision". This applies to new files
uploaded using either the web apis or the web interface.

The behavior is now consistent with the initial message set in
UploadComponent::createLinkItem() and ApisystemComponent::uploadGeneratetoken()