### PR TITLE
uploadGeneratetoken: Add support to optionally create new revision

### DIFF
--- a/modules/api/controllers/components/ApiComponent.php
+++ b/modules/api/controllers/components/ApiComponent.php
@@ -317,6 +317,10 @@ class Api_ApiComponent extends AppComponent
      * When passing the <b>folderid</b> param, the name of the newly created item,
      * if not supplied, the item will have the same name as <b>filename</b>.
      * @param checksum (Optional) The md5 checksum of the file to be uploaded.
+     * @param create_additional_revision (Optional) When a <b>checksum</b> is passed and
+     * the server already has the file, by default a reference to the existing
+     * bitstream will be added to the latest revision. By setting
+     * <b>create_additional_revision</b> to true, a new revision will be created.
      * @return An upload token that can be used to upload a file.
      *            If <b>folderid</b> is passed instead of <b>itemid</b>, a new item will be created
      *            in that folder, but the id of the newly created item will not be


### PR DESCRIPTION
This commit updates the "uploadGeneratetoken" API introducing the new
parameter "create_additional_revision" allowing to optionally change
the default behavior and ensure a new revision is created when:
  - a bitstream associated with the file already exists on the server
  - and the checksum parameter is specified
  - and the item updated has at least one revision

Since the http uploader doesn't specify the "checksum" parameter, the
problem is only reproducible using the web API.

For example, considering the following configuration:

```
 folder
   |--- item1 --- revision1
   |                 |--- bitstream1 (filename1)
   |
   |--- item2 --- revision1
   |                 |--- bitstream2 (filename2)
```

By default, trying to associate bitstream1 with item2 will result in
this configuration:

```
 folder
   |--- item1 --- revision1
   |                 |--- bitstream1 (filename1)
   |
   |--- item2 --- revision1
   |                 |--- bitstream2 (filename2)
   |                 |--- bitstream1 (filename1)
```

By setting the option "create_additional_revision" to True, the
following configuration will be obtained:

```
 folder
   |--- item1 --- revision1
   |                 |--- bitstream1 (filename1)
   |
   |--- item2 -|--- revision1
   |           |     |--- bitstream2 (filename2)
   |           |
   |           |--- revision2
   |           |     |--- bitstream1 (filename1)
```