### PR TITLE
Correct addmetadata item PUT rest endpoint for header 'content-type: …

### DIFF
--- a/core/controllers/components/ApiitemComponent.php
+++ b/core/controllers/components/ApiitemComponent.php
@@ -179,7 +179,7 @@ class ApiitemComponent extends AppComponent
      * @path /item/addmetadata/{id}
      * @http PUT
      * @param id The id of the item
-     * @param metadata The metadata list to add or update, should be passed in the request body
+     * @param metadata The metadata list to add or update, must be passed in the request body
      * as 'application/json'.
      * @param revision (Optional) Item Revision number to set metadata on, defaults to latest revision.
      * @return item on success,

--- a/core/controllers/components/ApiitemComponent.php
+++ b/core/controllers/components/ApiitemComponent.php
@@ -179,6 +179,8 @@ class ApiitemComponent extends AppComponent
      * @path /item/addmetadata/{id}
      * @http PUT
      * @param id The id of the item
+     * @param metadata The metadata list to add or update, should be passed in the request body
+     * as 'application/json'.
      * @param revision (Optional) Item Revision number to set metadata on, defaults to latest revision.
      * @return item on success,
      *              will fail if there are no revisions or the specified revision is not found.
@@ -190,7 +192,7 @@ class ApiitemComponent extends AppComponent
     {
         /** @var ApihelperComponent $apihelperComponent */
         $apihelperComponent = MidasLoader::loadComponent('Apihelper');
-        $apihelperComponent->validateParams($args, array('id'));
+        $apihelperComponent->validateParams($args, array('id', 'metadata'));
         $userDao = $apihelperComponent->getUser($args);
 
         $apihelperComponent->requirePolicyScopes(array(MIDAS_API_PERMISSION_SCOPE_WRITE_DATA));
@@ -204,17 +206,7 @@ class ApiitemComponent extends AppComponent
         $revisionNumber = array_key_exists('revision', $args) ? (int) $args['revision'] : null;
         $revision = $apihelperComponent->getItemRevision($item, $revisionNumber);
 
-        if (!array_key_exists(0, $args)) {
-            throw new Exception('Missing request body data.', MIDAS_INVALID_PARAMETER);
-        }
-        $jsonBody = json_decode($args[0]);
-        if ($jsonBody === null) {
-            throw new Exception('Request body data must be valid JSON.', MIDAS_INVALID_PARAMETER);
-        }
-        if (!array_key_exists('metadata', $jsonBody)) {
-            throw new Exception("Request body data missing key 'metadata'.", MIDAS_INVALID_PARAMETER);
-        }
-        $metadata = $jsonBody->metadata;
+        $metadata = $args['metadata'];
         foreach ($metadata as $metadatum) {
             if (!isset($metadatum->element) || !isset($metadatum->value)) {
                 throw new Exception("All metadata must have 'element' and 'value' keys.", MIDAS_INVALID_PARAMETER);

--- a/core/tests/controllers/api/RestCallItemMethodsTest.php
+++ b/core/tests/controllers/api/RestCallItemMethodsTest.php
@@ -75,10 +75,12 @@ class Core_RestCallItemMethodsTest extends RestCallMethodsTestCase
         // Write some metadata correctly.
         $this->resetAll();
         $this->params['useSession'] = 'true';
-        $this->params[0] = json_encode(array('metadata' => array(
+        $metadata = json_encode(array('metadata' => array(
             array('element' => 'key1', 'value' => 'val1'),
             array('element' => 'key2', 'value' => 'val2'),
         )));
+        $this->request->setHeader('Content-Type', 'application/json');
+        $this->request->setRawBody($metadata);
         $resp = $this->_callRestApi('PUT', $apiPath, $userDao);
         $this->_assertStatusOk($resp);
 
@@ -104,10 +106,12 @@ class Core_RestCallItemMethodsTest extends RestCallMethodsTestCase
         // Update key1, add key3, leave key2 alone.
         $this->resetAll();
         $this->params['useSession'] = 'true';
-        $this->params[0] = json_encode(array('metadata' => array(
+        $metadata = json_encode(array('metadata' => array(
             array('element' => 'key1', 'value' => 'newval1'),
             array('element' => 'key3', 'value' => 'val3'),
         )));
+        $this->request->setHeader('Content-Type', 'application/json');
+        $this->request->setRawBody($metadata);
         $resp = $this->_callRestApi('PUT', $apiPath, $userDao);
         $this->_assertStatusOk($resp);
 

--- a/modules/api/controllers/components/ApiComponent.php
+++ b/modules/api/controllers/components/ApiComponent.php
@@ -776,6 +776,8 @@ class Api_ApiComponent extends AppComponent
      *
      * @param token Authentication token
      * @param itemid The id of the item
+     * @param metadata The metadata list to add or update, should be passed in the request body
+     * as 'application/json'.
      * @param revision (Optional) Item Revision number to set metadata on, defaults to latest revision.
      * @return item on success,
      *              will fail if there are no revisions or the specified revision is not found.

--- a/modules/api/controllers/components/ApiComponent.php
+++ b/modules/api/controllers/components/ApiComponent.php
@@ -776,7 +776,7 @@ class Api_ApiComponent extends AppComponent
      *
      * @param token Authentication token
      * @param itemid The id of the item
-     * @param metadata The metadata list to add or update, should be passed in the request body
+     * @param metadata The metadata list to add or update, must be passed in the request body
      * as 'application/json'.
      * @param revision (Optional) Item Revision number to set metadata on, defaults to latest revision.
      * @return item on success,


### PR DESCRIPTION
…application/json'

Cleans up the addmetadata endpoint and test to require (and work when) the client passes the metadata list as the request body and specifies a request header of "content-type: application/json".