### PR TITLE
Skip geolocation and cleanup tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ before_script:
 script:
   - mkdir _test && cd _test
   - cmake ..
-  - ctest -j2 -V .
+  - ctest -E 'GeolocationLookup|PerformCleanup' -j2 -V .


### PR DESCRIPTION
These two sets of tests are highly flaky in Travis, and cause a lot of lost developer time.

The tests still exist, but will no longer be run in Travis.