### PR TITLE
Make the Vagrant box work with Windows hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(2) do |config|
         vmware_workstation.vmx['memsize'] = 4096
         vmware_workstation.vmx['numvcpus'] = 2
     end
-    config.vm.provision 'ansible' do |ansible|
+    config.vm.provision 'ansible_local' do |ansible|
         ansible.playbook = 'provisioning/ansible/site.yml'
     end
 end

--- a/provisioning/ansible/roles/python/tasks/main.yml
+++ b/provisioning/ansible/roles/python/tasks/main.yml
@@ -43,7 +43,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: pip install
-  pip: name={{ item }} virtualenv=/vagrant/env state=present
+  pip: name={{ item }} virtualenv=/home/vagrant/env state=present
   with_items:
     - mkdocs
     - pydas


### PR DESCRIPTION
**Warning:**

As of Vagrant 1.8.1, `ansible_local` will not work on Windows unless you fix the Vagrant source code by yourself. This will not be a problem anymore with next version.

Example:
- `C:\HashiCorp\Vagrant\embedded\gems\gems\vagrant-1.8.1\plugins\provisioners\ansible\config\guest.rb`  
  Replace line 40 with:

``` ruby
        # remote_path = Pathname.new(path).expand_path(@provisioning_path)
        remote_path = File.expand_path(path, @provisioning_path)
        # Remove drive letter if running on a Windows host
        remote_path = remote_path.gsub(/^[a-zA-Z]:/, "")
```
- `C:\HashiCorp\Vagrant\embedded\gems\gems\vagrant-1.8.1\plugins\provisioners\ansible\provisioner\guest.rb`  
  Replace line 55 with:

``` ruby
          # "ansible-galaxy --help && ansible-playbook --help",
          "ansible-galaxy info --help && ansible-playbook --help",
```
