### PR TITLE
Unhide Zend_Exception in UtilityComponent::run_sql_from_file

### DIFF
--- a/core/controllers/components/UtilityComponent.php
+++ b/core/controllers/components/UtilityComponent.php
@@ -390,7 +390,7 @@ class UtilityComponent extends AppComponent
                 $db->query($query);
             } catch (Zend_Exception $exception) {
                 if (trim($query) != '') {
-                    throw new Zend_Exception('Unable to connect.');
+                    throw $exception;
                 }
             }
         }


### PR DESCRIPTION
With this PR, error messages are way clearer than current `Unable to connect`:

![capture](https://cloud.githubusercontent.com/assets/2091902/14970278/f96ecb98-10c7-11e6-85c5-2a701af0f643.JPG)

_FYI, the error displayed here is because the [MySQL instance I used](https://hub.docker.com/_/mysql/) had [`NO_ZERO_DATE`](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date) enabled..._